### PR TITLE
Add Missing C_Timer Shim to Files with Added C_Timer

### DIFF
--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -41,8 +41,6 @@ local DropDB = QuestieLoader:ImportModule("DropDB")
 local QuestieQuest = QuestieLoader:ImportModule("QuestieQuest")
 ---@type QuestieQuestPrivate
 local _QuestieQuest = QuestieQuest.private
---- COMPATIBILITY ---
-local C_Timer = QuestieCompat.C_Timer
 
 --- A list of quests that will never be available, used to quickly skip quests.
 ---@alias AutoBlacklistString "rep"|"skill"|"race"|"class"|"rank"
@@ -115,6 +113,7 @@ QuestieDB.DoableStates = {
 local WOW_PROJECT_ID = QuestieCompat.WOW_PROJECT_ID
 local WOW_PROJECT_CLASSIC = QuestieCompat.WOW_PROJECT_CLASSIC
 local C_QuestLog = QuestieCompat.C_QuestLog
+local C_Timer = QuestieCompat.C_Timer
 local GetQuestTagInfo = QuestieCompat.GetQuestTagInfo
 local IsPlayerSpell = QuestieCompat.IsPlayerSpell
 local IsSpellKnownOrOverridesKnown = QuestieCompat.IsSpellKnownOrOverridesKnown

--- a/Database/QuestieDB.lua
+++ b/Database/QuestieDB.lua
@@ -41,6 +41,8 @@ local DropDB = QuestieLoader:ImportModule("DropDB")
 local QuestieQuest = QuestieLoader:ImportModule("QuestieQuest")
 ---@type QuestieQuestPrivate
 local _QuestieQuest = QuestieQuest.private
+--- COMPATIBILITY ---
+local C_Timer = QuestieCompat.C_Timer
 
 --- A list of quests that will never be available, used to quickly skip quests.
 ---@alias AutoBlacklistString "rep"|"skill"|"race"|"class"|"rank"

--- a/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
+++ b/Modules/Journey/tabs/QuestsByZone/QuestsByZone.lua
@@ -27,6 +27,8 @@ local AceGUI = LibStub("AceGUI-3.0")
 local IsSpellKnownOrOverridesKnown = QuestieCompat.IsSpellKnownOrOverridesKnown
 local IsPlayerSpell = QuestieCompat.IsPlayerSpell
 local zoneTreeFrame
+--- COMPATIBILITY ---
+local C_Timer = QuestieCompat.C_Timer
 
 ---Restore the previously selected quest in the zone tree
 ---@param treeFrame table @The AceGUI TreeGroup frame

--- a/Modules/QuestieAnnounce.lua
+++ b/Modules/QuestieAnnounce.lua
@@ -10,13 +10,12 @@ local QuestieLib = QuestieLoader:ImportModule("QuestieLib")
 local QuestieLink = QuestieLoader:ImportModule("QuestieLink")
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
---- COMPATIBILITY ---
-local C_Timer = QuestieCompat.C_Timer
 
 --- COMPATIBILITY ---
 local IsInGroup = QuestieCompat.IsInGroup
 local IsInRaid = QuestieCompat.IsInRaid
 local LE_PARTY_CATEGORY_INSTANCE = QuestieCompat.LE_PARTY_CATEGORY_INSTANCE
+local C_Timer = QuestieCompat.C_Timer
 
 local itemCache = {} -- cache data since this happens on item looted it could happen a lot with auto loot
 

--- a/Modules/QuestieAnnounce.lua
+++ b/Modules/QuestieAnnounce.lua
@@ -10,6 +10,8 @@ local QuestieLib = QuestieLoader:ImportModule("QuestieLib")
 local QuestieLink = QuestieLoader:ImportModule("QuestieLink")
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
+--- COMPATIBILITY ---
+local C_Timer = QuestieCompat.C_Timer
 
 --- COMPATIBILITY ---
 local IsInGroup = QuestieCompat.IsInGroup

--- a/Modules/QuestieDebugOffer.lua
+++ b/Modules/QuestieDebugOffer.lua
@@ -16,6 +16,9 @@ local QuestieCorrections = QuestieLoader:ImportModule("QuestieCorrections")
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
 
+--- COMPATIBILITY ---
+local C_Timer = QuestieCompat.C_Timer
+
 local DebugInformation = {} -- stores text of debug data dump per session
 local debugIndex = 0 -- current debug index, used so we can still retrieve info from previous offers
 local openDebugWindows = {} -- determines if existing debug window is already open, prevents duplicates

--- a/Modules/QuestieDebugOffer.lua
+++ b/Modules/QuestieDebugOffer.lua
@@ -16,9 +16,6 @@ local QuestieCorrections = QuestieLoader:ImportModule("QuestieCorrections")
 ---@type l10n
 local l10n = QuestieLoader:ImportModule("l10n")
 
---- COMPATIBILITY ---
-local C_Timer = QuestieCompat.C_Timer
-
 local DebugInformation = {} -- stores text of debug data dump per session
 local debugIndex = 0 -- current debug index, used so we can still retrieve info from previous offers
 local openDebugWindows = {} -- determines if existing debug window is already open, prevents duplicates
@@ -31,6 +28,9 @@ local PosY = 0
 local target = "target"
 local player = "player"
 local questnpc = "questnpc"
+
+--- COMPATIBILITY ---
+local C_Timer = QuestieCompat.C_Timer
 
 local _, playerRace = UnitRace(player)
 local playerClass = UnitClassBase(player)


### PR DESCRIPTION
Resolves `Questie: [ERROR] Error during initialization! Interface\AddOns\Questie-335\Database\QuestieDB.lua:571: attempt to index global 'C_Timer' (a nil value)` error after database recompile
C_Timer was added to QuestieDb.lua
There exists a C_Timer shim in \Compat\Compat.lua line 168 that emulates/replaces the Blizzard API call that does not exist in 3.3.5a
Added load of C_Timer shim to QuestieDB.lua
Discovered 3 other files with C_Timer without a load of this shim: QuestsByZone.lua, QuestieAnnounce.lua, and QuestieDebugOffer.lua
Added load of C_Timer shim to QuestsByZone.lua, QuestieAnnounce.lua, and QuestieDebugOffer.lua