### PR TITLE
Workaround for error when entering Vanilla & BC instances in QuestieMap.lua, cleanup no longer needed C_Timer shim in QuestieCorrections.lua

### DIFF
--- a/Database/Corrections/QuestieCorrections.lua
+++ b/Database/Corrections/QuestieCorrections.lua
@@ -57,9 +57,6 @@ local IsleOfQuelDanas = QuestieLoader:ImportModule("IsleOfQuelDanas")
 --- Automatic corrections
 local QuestieItemStartFixes = QuestieLoader:ImportModule("QuestieItemStartFixes")
 
---- COMPATIBILITY ---
-local C_Timer = QuestieCompat.C_Timer
-
 --[[
     This file load the corrections of the database files.
 

--- a/Modules/Map/QuestieMap.lua
+++ b/Modules/Map/QuestieMap.lua
@@ -276,16 +276,16 @@ end
 function QuestieMap.GetScaleValue()
     local mapId = HBDPins.worldmapProvider:GetMap():GetMapID();
     local scaling = 1;
-    if C_Map and C_Map.GetMapInfo then
-        local mapInfo = C_Map.GetMapInfo(mapId)
-        if (mapInfo.mapType == 0) then     --? Cosmic, This is probably not needed but for the sake of completion...
-            scaling = 0.85
-        elseif (mapInfo.mapType == 1) then -- World
-            scaling = 0.85
-        elseif (mapInfo.mapType == 2) then -- Continent
-            scaling = 0.9
-        end
-    end
+--    if C_Map and C_Map.GetMapInfo then
+--        local mapInfo = C_Map.GetMapInfo(mapId)
+--       if (mapInfo.mapType == 0) then     --? Cosmic, This is probably not needed but for the sake of completion...
+--            scaling = 0.85
+--        elseif (mapInfo.mapType == 1) then -- World
+--            scaling = 0.85
+--        elseif (mapInfo.mapType == 2) then -- Continent
+--            scaling = 0.9
+--        end
+--    end
     return scaling
 end
 

--- a/Modules/Map/QuestieMap.lua
+++ b/Modules/Map/QuestieMap.lua
@@ -274,18 +274,21 @@ end
 
 ---@return number @A scale value that is based of the map currently open, smaller icons for World and Continent
 function QuestieMap.GetScaleValue()
-    local mapId = HBDPins.worldmapProvider:GetMap():GetMapID();
+    local map = HBDPins.worldmapProvider and HBDPins.worldmapProvider:GetMap()
+    local mapId = map and map:GetMapID()
     local scaling = 1;
---    if C_Map and C_Map.GetMapInfo then
---        local mapInfo = C_Map.GetMapInfo(mapId)
---       if (mapInfo.mapType == 0) then     --? Cosmic, This is probably not needed but for the sake of completion...
---            scaling = 0.85
---        elseif (mapInfo.mapType == 1) then -- World
---            scaling = 0.85
---        elseif (mapInfo.mapType == 2) then -- Continent
---            scaling = 0.9
---        end
---    end
+    if C_Map and C_Map.GetMapInfo and mapId then
+        local mapInfo = C_Map.GetMapInfo(mapId)
+        if not mapInfo then
+            Questie:Debug(Questie.DEBUG_DEVELOP, "[QuestieMap:GetScaleValue] No map info for uiMapID:", tostring(mapId))
+        elseif (mapInfo.mapType == 0) then     --? Cosmic, This is probably not needed but for the sake of completion...
+            scaling = 0.85
+        elseif (mapInfo.mapType == 1) then -- World
+            scaling = 0.85
+        elseif (mapInfo.mapType == 2) then -- Continent
+            scaling = 0.9
+        end
+    end
     return scaling
 end
 


### PR DESCRIPTION
Was running Magister's Terrace (BC instance) for the white birdie mount. When entering, the following error would pop up:
```
Message: ...erface\AddOns\Questie-335\Modules\Map\QuestieMap.lua:281: attempt to index local 'mapInfo' (a nil value)
Time: 04/09/26 21:13:02
Count: 5
Stack: (tail call): ?
[C]: ?
...erface\AddOns\Questie-335\Modules\Map\QuestieMap.lua:281: in function `GetScaleValue'
...erface\AddOns\Questie-335\Modules\Map\QuestieMap.lua:383: in function `ProcessQueue'
...dOns\Questie-335\Modules\QuestieMenu\QuestieMenu.lua:101: in function <...dOns\Questie-335\Modules\QuestieMenu\QuestieMenu.lua:81>
...dOns\Questie-335\Modules\QuestieMenu\QuestieMenu.lua:162: in function <...dOns\Questie-335\Modules\QuestieMenu\QuestieMenu.lua:125>
...dOns\Questie-335\Modules\QuestieMenu\QuestieMenu.lua:261: in function `OnLogin'
...ce\AddOns\Questie-335\Modules\Quest\QuestieQuest.lua:353: in function `?'
...ce\AddOns\Questie-335\Modules\Quest\QuestieQuest.lua:393: in function `callback'
Interface\AddOns\Questie-335\Compat\Compat.lua:155: in function <Interface\AddOns\Questie-335\Compat\Compat.lua:153>
```
Noticed the same happening when loading into Deadmines or Stockades. Narrowed it down to the following function, looks like it scales the icons depending on the view (line 276-290):
```
function QuestieMap.GetScaleValue()
    local mapId = HBDPins.worldmapProvider:GetMap():GetMapID();
    local scaling = 1;
--    if C_Map and C_Map.GetMapInfo then
--        local mapInfo = C_Map.GetMapInfo(mapId)
--        if (mapInfo.mapType == 0) then     --? Cosmic, This is probably not needed but for the sake of completion...
--            scaling = 0.85
--        elseif (mapInfo.mapType == 1) then -- World
--            scaling = 0.85
--        elseif (mapInfo.mapType == 2) then -- Continent
--            scaling = 0.9
--        end
--    end
    return scaling
end
```
My head started spinning when I tried to trace C_Map.GetMapInfo back through Compat.lua, so as a workaround, when you comment out line 279-288, the error doesn't pop up.  The icons are bigger in the continent & world maps, but that's a livable workaround while someone smarter than me figures out why line 280 `local mapInfo = C_Map.GetMapInfo(mapId)` isn't working.

Also saw the C_Timer in QuestieCorrections.lua line 232 was removed, which means it didn't need the C_Timer shim any longer.