### PR TITLE
fix: correct icon location when using magnify

### DIFF
--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -31,7 +31,7 @@ function QuestieMap.utils:SetDrawOrder(frame)
             frameLevel = frameLevel - 1 -- This is to make sure that manual icons are always below other icons
         end
         local frameStrata = WorldMapFrame:GetFrameStrata()
-        frame:SetParent(WorldMapFrame)
+        frame:SetParent(WorldMapButton)
         frame:SetFrameStrata(frameStrata)
         frame:SetFrameLevel(frameLevel)
     end

--- a/Modules/WorldMapButton/WorldMapButton.lua
+++ b/Modules/WorldMapButton/WorldMapButton.lua
@@ -18,6 +18,15 @@ local mapButton
 function WorldMapButton.Initialize()
     mapButton = KButtons:Add("QuestieWorldMapButtonTemplate", "BUTTON")
 	WorldMapButton.Toggle(Questie.db.profile.mapShowHideEnabled)
+	local worldMapButtonFrame = _G.WorldMapButton
+
+    if worldMapButtonFrame then
+        mapButton:SetParent(worldMapButtonFrame)
+        mapButton:ClearAllPoints()
+        mapButton:SetFrameStrata("TOOLTIP")
+        mapButton:SetFrameLevel(worldMapButtonFrame:GetFrameLevel() + 1)
+        mapButton:SetPoint("TOPRIGHT", worldMapButtonFrame, "TOPRIGHT", -4, -4)
+    end
 
     Questie.WorldMap = {
         Button = mapButton


### PR DESCRIPTION
omit icons being in the wrong location including outside the map area when using magnify (allows you to zoom the worldmap)

see https://github.com/rissole/Magnify-WotLK/issues/4#issuecomment-3345756172

i did a short test without magnify, this does not seem to do anything when not using magnify