### PR TITLE
fix: refresh unit tooltip after appending objectives

### DIFF
--- a/Modules/Tooltips/TooltipHandler.lua
+++ b/Modules/Tooltips/TooltipHandler.lua
@@ -48,6 +48,7 @@ function _QuestieTooltips:AddUnitDataToTooltip()
             for _, v in pairs (tooltipData) do
                 GameTooltip:AddLine(v)
             end
+            self:Show()
         end
         QuestieTooltips.lastGametooltipCount = _QuestieTooltips:CountTooltip()
     end


### PR DESCRIPTION
I've noticed that using Questie with TipTac has some formatting issues
<img width="270" height="175" alt="image" src="https://github.com/user-attachments/assets/e6263c75-1721-4188-a629-d94b87e271b4" />

This PR simply forces a refresh to ensure that Questie's objectives remain inside the tooltip and do not extend outside of it or get drawn over by other contents of the tooltip.
<img width="290" height="218" alt="image" src="https://github.com/user-attachments/assets/5895988b-ada6-45a4-9aef-04611c980bd8" />
