### PR TITLE
QuestieComms: encapsulate addon packets in b64

### DIFF
--- a/Modules/Libs/QuestieSerializer.lua
+++ b/Modules/Libs/QuestieSerializer.lua
@@ -317,17 +317,46 @@ function QuestieSerializer:SetupStream(encoding)
     clearHashes()
 end
 
+function QuestieSerializer:Base64Encode(data)
+    local b='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+    return ((data:gsub('.', function(x)
+        local r,b='',x:byte()
+        for i=8,1,-1 do r=r..(b%2^i-b%2^(i-1)>0 and '1' or '0') end
+        return r;
+    end)..'0000'):gsub('%d%d%d?%d?%d?%d?', function(x)
+        if (#x < 6) then return '' end
+        local c=0
+        for i=1,6 do c=c+(x:sub(i,i)=='1' and 2^(6-i) or 0) end
+        return b:sub(c+1,c+1)
+    end)..({ '', '==', '=' })[#data%3+1])
+end
+
+function QuestieSerializer:Base64Decode(data)
+    local b='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+    return (data:gsub('.', function(x)
+        if (x == '=') then return '' end
+        local r,f='',(b:find(x)-1)
+        for i=6,1,-1 do r=r..(f%2^i-f%2^(i-1)>0 and '1' or '0') end
+        return r;
+    end):gsub('%d%d%d?%d?%d?%d?%d?%d?', function(x)
+        if (#x ~= 8) then return '' end
+        local c=0
+        for i=1,8 do c=c+(x:sub(i,i)=='1' and 2^(8-i) or 0) end
+            return string.char(c)
+    end))
+end
+
 function QuestieSerializer:Serialize(tab, encoding)
     QuestieSerializer:SetupStream(encoding)
     self.objectCount = 0
     --QuestieSerializer:WriteKeyValuePair("meta", {protocolVersion = 1, mode="1short"})
     QuestieSerializer:WriteKeyValuePair(1, tab)
-    return self.stream:Save()
+    return QuestieSerializer:Base64Encode(self.stream:Save())
 end
 
 function QuestieSerializer:Deserialize(data, encoding)
     QuestieSerializer:SetupStream(encoding)
-    self.stream:Load(data)
+    self.stream:Load(QuestieSerializer:Base64Decode(data))
     --local meta = _ReadTable(self, 1)
     local retData = _ReadTable(self, 1)
     return retData[1]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ All 16 open issues from the archived widxwer repo have been resolved, and this f
 
 A fork of the WoW Classic Questie addon aiming to provide compatibility with Wrath of the Lich King client version 3.3.5a (12340).
 # Installation
-- [Download](https://github.com/balintx/Questie/archive/refs/tags/335.zip) the archive.
+- [Download](https://github.com/Aldori15/Questie/archive/refs/heads/335.zip) the archive.
 - Extract it into `Interface/AddOns/` directory, folder name should be `Questie-335`.
 
 ## Questie Information

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ All 16 open issues from the archived widxwer repo have been resolved, and this f
 
 A fork of the WoW Classic Questie addon aiming to provide compatibility with Wrath of the Lich King client version 3.3.5a (12340).
 # Installation
-- [Download](https://github.com/balintx/Questie/archive/refs/tags/warmanefix.zip) the archive.
+- [Download](https://github.com/balintx/Questie/archive/refs/tags/335.zip) the archive.
 - Extract it into `Interface/AddOns/` directory, folder name should be `Questie-335`.
 
 ## Questie Information

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ All 16 open issues from the archived widxwer repo have been resolved, and this f
 
 A fork of the WoW Classic Questie addon aiming to provide compatibility with Wrath of the Lich King client version 3.3.5a (12340).
 # Installation
-- [Download](https://github.com/Aldori15/Questie/archive/refs/heads/335.zip) the archive.
+- [Download](https://github.com/balintx/Questie/archive/refs/tags/warmanefix.zip) the archive.
 - Extract it into `Interface/AddOns/` directory, folder name should be `Questie-335`.
 
 ## Questie Information


### PR DESCRIPTION
TrinityCore/MaNGOS 3.3.5 (or whatever Warmane is using) have issues with specific characters in addon messages, causing Questie-335 QuestieComms not to work at all.

This patch encapsulates the serialized data in base64, which I can confirm solves the issue on Warmane, party communication is now working, and it should not interfere with other types of core where Questie-335 worked so far.

fixes #101 