### PR TITLE
feat: Implement QuestieOptionsDefaultsOverride optionnal addon

### DIFF
--- a/Modules/Options/QuestieOptionsDefaults.lua
+++ b/Modules/Options/QuestieOptionsDefaults.lua
@@ -1,8 +1,22 @@
 ---@class QuestieOptionsDefaults
 local QuestieOptionsDefaults = QuestieLoader:CreateModule("QuestieOptionsDefaults");
 
+local function ApplyOverrides(target, overrides)
+    if type(overrides) ~= "table" then
+        return
+    end
+
+    for key, value in pairs(overrides) do
+        if type(value) == "table" and type(target[key]) == "table" then
+            ApplyOverrides(target[key], value)
+        else
+            target[key] = value
+        end
+    end
+end
+
 function QuestieOptionsDefaults:Load()
-    return {
+    local defaults = {
         profile = {
             resetDailyQuests = true,
             weeklyResetDay = 4,
@@ -262,4 +276,10 @@ function QuestieOptionsDefaults:Load()
             journeyKeybindDefaultApplied = false,
         }
     }
+
+    if QuestieOptionsDefaultsOverride then
+        ApplyOverrides(defaults, QuestieOptionsDefaultsOverride)
+    end
+
+    return defaults
 end

--- a/Questie-335.toc
+++ b/Questie-335.toc
@@ -8,7 +8,7 @@
 ## Notes-frFR: Assistant de quête
 ## Version: 9.7.9-335
 ## RequiredDeps:
-## OptionalDeps: Ace3, CallbackHandler-1.0, HereBeDragons, LibDataBroker-1.1, LibDBIcon-1.0, LibSharedMedia-3.0, LibStub, LibUIDropDownMenu
+## OptionalDeps: Ace3, CallbackHandler-1.0, HereBeDragons, LibDataBroker-1.1, LibDBIcon-1.0, LibSharedMedia-3.0, LibStub, LibUIDropDownMenu, QuestieOptionsDefaultsOverride
 ## SavedVariables: QuestieConfig
 ## SavedVariablesPerCharacter: QuestieConfigCharacter
 ## X-Curse-Project-ID: 334372

--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ A fork of the WoW Classic Questie addon aiming to provide compatibility with Wra
 - [Download](https://github.com/Aldori15/Questie/archive/refs/heads/335.zip) the archive.
 - Extract it into `Interface/AddOns/` directory, folder name should be `Questie-335`.
 
+## Optional default settings override
+
+Questie-335 supports an optional addon named `QuestieOptionsDefaultsOverride` that can override Questie's default settings without modifying the main addon files. To use it, create an `Interface/AddOns/QuestieOptionsDefaultsOverride/` directory containing `QuestieOptionsDefaultsOverride.toc` and `QuestieOptionsDefaultsOverride.lua`. The Lua file only needs to define the settings that should differ from Questie's defaults, for example:
+
+```lua
+QuestieOptionsDefaultsOverride = {
+    profile = {
+        questieShutUp = true,
+    },
+}
+```
+
+If `QuestieOptionsDefaultsOverride` is not installed, Questie-335 loads normally and uses its standard default settings.
+
 ## Questie Information
 - [Frequently Asked Questions](https://github.com/Questie/Questie/wiki/FAQ)
 - Come chat with us on [our Discord server](https://discord.gg/s33MAYKeZd).


### PR DESCRIPTION
Hi !

This is a little addition allowing to create an optionnal addon which override default configs

Here is an example of such addon
[QuestieOptionsDefaultsOverride.zip](https://github.com/user-attachments/files/31196027/QuestieOptionsDefaultsOverride.zip)

This is useful in my example case where I want to deploy Questie on my custom client with different default values, but without having to edit & fork main repo 👼 

Best regards, 
MacWarrior.
