### PR TITLE
Fix quest detail frame closing after quest acceptance on 3.3.5a

### DIFF
--- a/Modules/Auto/QuestieAuto.lua
+++ b/Modules/Auto/QuestieAuto.lua
@@ -366,11 +366,7 @@ function QuestieAuto.GOSSIP_CLOSED()
 end
 
 function QuestieAuto.QUEST_ACCEPTED()
-    if QuestieCompat.Is335 then
-        return
-    end
-
-    if Questie.db.profile.bugWorkarounds == true and QuestFrameDetailPanel and QuestFrameDetailPanel:IsVisible() and QuestFrameCloseButton then
+    if not QuestieCompat.Is335 and Questie.db.profile.bugWorkarounds == true and QuestFrameDetailPanel and QuestFrameDetailPanel:IsVisible() and QuestFrameCloseButton then
         QuestFrameCloseButton:Click()
     end
 end

--- a/Modules/Auto/QuestieAuto.lua
+++ b/Modules/Auto/QuestieAuto.lua
@@ -366,6 +366,10 @@ function QuestieAuto.GOSSIP_CLOSED()
 end
 
 function QuestieAuto.QUEST_ACCEPTED()
+    if QuestieCompat.Is335 then
+        return
+    end
+
     if Questie.db.profile.bugWorkarounds == true and QuestFrameDetailPanel and QuestFrameDetailPanel:IsVisible() and QuestFrameCloseButton then
         QuestFrameCloseButton:Click()
     end


### PR DESCRIPTION
On a real WoW 3.3.5a client, QUEST_ACCEPTED can fire while QuestFrameDetailPanel is still visible.

The current bug workaround then clicks QuestFrameCloseButton, which causes the quest detail text to disappear immediately after the quest is accepted.

This appears to be a workaround inherited from newer Classic client behavior and is not needed on the 3.3.5a client.

This change skips that workaround when QuestieCompat.Is335 is true.

Tested on:
- WoW 3.3.5a client
- AzerothCore
- Questie 335 branch